### PR TITLE
setup helpers: fix ownership ordering and gate rustup on cargo's version

### DIFF
--- a/PI_ZERO_2W_RUST_BUILD.md
+++ b/PI_ZERO_2W_RUST_BUILD.md
@@ -1,0 +1,119 @@
+# Building `sniffle_receiver_rust` for the Raspberry Pi Zero 2 W
+
+`setup_capture_helper_debian-based.sh` builds `Sniffle/sniffle_receiver_rust`
+natively on the capture host with a plain `cargo build --release --offline`
+(see `build_sniffle_receiver_rust()`). **That step cannot succeed on a
+Raspberry Pi Zero 2 W (aarch64).** The 64-bit `rustc` on that board segfaults
+while compiling this crate, and no build flag, memory tuning, or toolchain
+upgrade on the Pi fixes it. Cross-compile the binary on an x86_64 host and copy
+it over instead.
+
+This is aarch64-specific. The crate's own README documents a successful native
+build on the original **Pi Zero W (32-bit ARMv6)**; that path still works. Only
+the 64-bit target is affected.
+
+## The failure
+
+A native build (or even `cargo check`) on the Pi ends with a segfault, not a
+type error:
+
+```
+error: could not compile `sniffle_receiver_rust`; 4 warnings emitted
+Caused by:
+  process didn't exit successfully: `rustc ... src/main.rs ...`
+  (signal: 11, SIGSEGV: invalid memory reference)
+```
+
+On Bookworm's apt toolchain (`rustc` 1.63 / LLVM 14) the crash is inside the
+LLVM backend (`AsmPrinter::emitFunctionBody` -> `MCContext::createTempSymbol`).
+On a current rustup toolchain (`rustc` 1.97) the crash moves earlier, into the
+front end — `cargo check` alone (`--emit=metadata`, no codegen) already
+segfaults. `rustc` prints its generic "increase stack size with
+`RUST_MIN_STACK=...`" hint, but the header reads `rustc interrupted by SIGSEGV`,
+not "has overflowed its stack": that hint is a red herring here.
+
+## What it is NOT
+
+Each of these was tested on the Pi and ruled out:
+
+- **Not out of memory.** A memory sampler showed ~289 MB free and swap barely
+  touched at the instant of the crash, with 2+ GB of swap active. It also
+  crashes in ~2 s, far too fast to exhaust memory.
+- **Not compiler-thread stack overflow.** `RUST_MIN_STACK` at 512 MB and 1 GB
+  changed nothing (the hint's suggested value doubled, confirming the variable
+  was honored — it just did not matter).
+- **Not `codegen-units` / LTO / opt-level.** `lto=off`, `codegen-units=16`,
+  `opt-level=1`, and `codegen-units=1` all crash at the same point. The
+  front-end `cargo check` crash proves codegen settings are irrelevant.
+- **Not the source.** The identical source `cargo check`s cleanly on an x86_64
+  host in under a second. A trivial hello-world compiles *and runs* on the Pi's
+  modern toolchain, so the toolchain install is healthy.
+
+The remaining explanation is a defect in the **aarch64 `rustc` binary** when
+compiling this crate — reproducible across two very different rustc/LLVM
+versions on the same board. The likely trigger is the large auto-generated
+constant table in `src/advdata_constants.rs` (the BT-SIG company-identifier
+list is a single multi-thousand-element `static` array); the x86_64 front end
+handles it fine, the aarch64 one does not.
+
+## The fix: cross-compile a static aarch64 binary on x86_64
+
+Build a **statically linked `aarch64-unknown-linux-musl`** binary. musl +
+`rust-lld` is self-contained, so this needs **no gcc cross-linker** and the
+result has **no runtime library dependencies** on the Pi.
+
+Prerequisites on the x86_64 host: `rustup` with a recent stable toolchain
+(>= 1.79) and the musl target. The bundled `rust-lld` ships with the toolchain.
+
+```bash
+# one-time: add the target
+rustup target add aarch64-unknown-linux-musl
+
+# from the crate directory
+cd Sniffle/sniffle_receiver_rust_src
+rm -f Cargo.lock
+
+# point the linker at the toolchain's bundled rust-lld (no gcc cross-toolchain needed)
+LLD="$(rustc --print sysroot)/lib/rustlib/$(rustc -vV | sed -n 's/host: //p')/bin/rust-lld"
+CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER="$LLD" \
+CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS="-Clinker-flavor=ld.lld" \
+  cargo build --release --target aarch64-unknown-linux-musl
+```
+
+That produces:
+
+```
+target/aarch64-unknown-linux-musl/release/sniffle_receiver_rust
+# ELF 64-bit LSB executable, ARM aarch64, statically linked, stripped
+```
+
+Copy it to the Pi, into the path `central_app_launcher.py` expects
+(`Sniffle/sniffle_receiver_rust`, next to `Sniffle/python_cli/`):
+
+```bash
+scp target/aarch64-unknown-linux-musl/release/sniffle_receiver_rust \
+    pi@<pi-host>:/tmp/sniffle_receiver_rust
+ssh pi@<pi-host> \
+  'install -m 755 /tmp/sniffle_receiver_rust ~/Blue2thprinting/Sniffle/sniffle_receiver_rust'
+```
+
+Verify on the Pi:
+
+```bash
+~/Blue2thprinting/Sniffle/sniffle_receiver_rust -h        # prints usage, exits 0
+# live check against a flashed Sonoff dongle (active scan is the launcher's mode):
+sudo ~/Blue2thprinting/Sniffle/sniffle_receiver_rust \
+     -s=/dev/ttyUSB0 -o=/tmp/t.pcap -A --duration=12
+# expect a "+10s: ... crlf_err=0 dec_err=0" status line and a "DONE:" summary
+```
+
+Let the binary self-terminate via `--duration`; wrapping it in an external
+`timeout` can kill it before it flushes the pcap header, leaving a 0-byte file.
+
+## Note for `setup_capture_helper_debian-based.sh`
+
+On an aarch64 capture host the `build_sniffle_receiver_rust()` step will fail no
+matter what — it is not the cargo-version problem that the analysis helper's
+rustup gate (commit 995bcfb) addresses, so installing rustup on the Pi does not
+help. On such a host, skip that build step and drop in a cross-built binary
+produced as above. The 32-bit Pi Zero W is unaffected and still builds natively.

--- a/setup_analysis_helper_debian-based.sh
+++ b/setup_analysis_helper_debian-based.sh
@@ -14,6 +14,10 @@ USERNAME="$SUDO_USER"
 BASE_PATH="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
 echo "Username detected as '$USERNAME'."
 echo "Repo detected at '$BASE_PATH'."
+# The steps below use relative paths (./venv, cd Analysis), so they only work
+# when the CWD is the repo. Invoked by absolute path from elsewhere, the venv
+# lands in the caller's directory and `cd Analysis` fails.
+cd "$BASE_PATH" || exit -1
 
 if [[ ! -f "$BASE_PATH/Analysis/handle_venv.py" ]]; then
     echo "Could not find Analysis/handle_venv.py relative to this script. Run setup from inside a Blue2thprinting checkout."
@@ -47,7 +51,27 @@ echo "====================================================================="
 # install the current stable toolchain into the invoking user's home.
 # build-essential / curl / pkg-config are needed for native crate compiles.
 sudo apt-get install -y build-essential curl ca-certificates pkg-config
-if ! sudo -u "$USERNAME" bash -lc 'command -v cargo' >/dev/null 2>&1; then
+# Gate on the cargo VERSION, not on cargo merely being present. The capture-side
+# setup apt-installs `rustc cargo` (1.65 on Bookworm), which satisfies a bare
+# `command -v cargo` test but is rejected by the >= 1.79 requirement below --
+# so on a combined capture+analysis host rustup would be skipped and both
+# builds at the end of this script would fail on a version error.
+RUST_MIN=1.79   # jsonschema 0.30 sets rust-version = 1.79
+CARGO_VER=""
+# Sets CARGO_VER. Returns success when cargo is absent, unparseable, or older
+# than $RUST_MIN -- i.e. when the toolchain still needs installing.
+cargo_too_old () {
+    local major minor min_major min_minor
+    CARGO_VER="$(sudo -u "$USERNAME" bash -lc 'cargo --version' 2>/dev/null | awk '{print $2}')"
+    [[ "$CARGO_VER" =~ ^([0-9]+)\.([0-9]+) ]] || return 0
+    major="${BASH_REMATCH[1]}"; minor="${BASH_REMATCH[2]}"
+    min_major="${RUST_MIN%%.*}"; min_minor="${RUST_MIN##*.}"
+    (( major > min_major )) && return 1
+    (( major < min_major )) && return 0
+    (( minor < min_minor ))
+}
+if cargo_too_old; then
+    echo "Installing rustup (cargo ${CARGO_VER:-not found} is below $RUST_MIN)."
     sudo -u "$USERNAME" sh -c "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal"
 fi
 CARGO_BIN="$(sudo -u "$USERNAME" bash -lc 'command -v cargo' 2>/dev/null)"
@@ -55,7 +79,13 @@ if [[ -z "$CARGO_BIN" ]]; then
     echo "Rust toolchain install failed — 'cargo' is not on \$PATH for $USERNAME."
     exit -1
 fi
-echo "Using cargo: $CARGO_BIN"
+if cargo_too_old; then
+    echo "cargo ${CARGO_VER:-(unknown version)} at $CARGO_BIN is older than $RUST_MIN, which the Rust workspaces require."
+    echo "The apt-installed cargo is probably still ahead of rustup's on \$PATH for $USERNAME."
+    echo "Fix with: sudo apt-get remove cargo rustc   (or put \$HOME/.cargo/bin first in \$PATH)"
+    exit -1
+fi
+echo "Using cargo: $CARGO_BIN ($CARGO_VER)"
 
 python3 -m venv ./venv
 source ./venv/bin/activate
@@ -139,6 +169,12 @@ echo "  * Analysis/rust/ — Blue2thprinting-specific tools"
 echo "      (wigle-to-BTIDES, import-all-BTIDES)"
 echo "Release builds, may take a minute or two."
 echo "================================================================================="
+# Hand the tree back before dropping privileges. Everything above ran as root
+# -- the submodule checkout, the venv, the pip installs -- so cargo running as
+# $USERNAME cannot create target/ yet. That failure would exit -1 below, i.e.
+# before the chown at the end of this script, leaving the checkout root-owned
+# and every retry (git pull, submodule update, this script) failing the same way.
+sudo chown -R "$USERNAME" "$BASE_PATH"
 sudo -u "$USERNAME" bash -lc "cd '$BASE_PATH/Analysis/BTIDES_Schema/rust' && cargo build --release"
 if [ $? -ne 0 ]; then
     echo "cargo build failed in Analysis/BTIDES_Schema/rust. Check the output above."

--- a/setup_analysis_helper_macOS.sh
+++ b/setup_analysis_helper_macOS.sh
@@ -15,6 +15,10 @@ USERNAME="$SUDO_USER"
 BASE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 echo "Username detected as '$USERNAME'."
 echo "Repo detected at '$BASE_PATH'."
+# The steps below use relative paths (./venv, cd scapy, cd ./Analysis/...), so
+# they only work when the CWD is the repo. Invoked by absolute path from
+# elsewhere, the venv lands in the caller's directory and the cd's fail.
+cd "$BASE_PATH" || exit -1
 
 if [[ ! -f "$BASE_PATH/Analysis/handle_venv.py" ]]; then
     echo "Could not find Analysis/handle_venv.py relative to this script. Run setup from inside a Blue2thprinting checkout."
@@ -49,9 +53,28 @@ echo ""
 echo "====================================================================="
 echo "Installing Rust toolchain (needed to build Analysis/BTIDES_Schema/rust/ workspace)."
 echo "====================================================================="
+# Gate on the cargo VERSION, not on cargo merely being present. A cargo left
+# over from an older rustup or an older brew formula satisfies a bare
+# `command -v cargo` test but is rejected by the >= 1.79 requirement below, so
+# the install would be skipped and both builds at the end would fail.
+RUST_MIN=1.79   # jsonschema 0.30 sets rust-version = 1.79
+CARGO_VER=""
+# Sets CARGO_VER. Returns success when cargo is absent, unparseable, or older
+# than $RUST_MIN -- i.e. when the toolchain still needs installing.
+cargo_too_old () {
+    local major minor min_major min_minor
+    CARGO_VER="$(sudo -u "$USERNAME" bash -lc 'cargo --version' 2>/dev/null | awk '{print $2}')"
+    [[ "$CARGO_VER" =~ ^([0-9]+)\.([0-9]+) ]] || return 0
+    major="${BASH_REMATCH[1]}"; minor="${BASH_REMATCH[2]}"
+    min_major="${RUST_MIN%%.*}"; min_minor="${RUST_MIN##*.}"
+    (( major > min_major )) && return 1
+    (( major < min_major )) && return 0
+    (( minor < min_minor ))
+}
 # Install as the invoking user — brew refuses to run as root.
-if ! sudo -u "$USERNAME" bash -lc 'command -v cargo' >/dev/null 2>&1; then
-    sudo -u "$USERNAME" brew install rust
+if cargo_too_old; then
+    echo "Installing rust (cargo ${CARGO_VER:-not found} is below $RUST_MIN)."
+    sudo -u "$USERNAME" brew install rust || sudo -u "$USERNAME" brew upgrade rust
 fi
 # Re-resolve cargo for the current (root) shell so the build step below can find it.
 USER_HOME="$(eval echo ~"$USERNAME")"
@@ -60,7 +83,13 @@ if [[ -z "$CARGO_BIN" ]]; then
     echo "Rust toolchain install failed — 'cargo' is not on \$PATH for $USERNAME."
     exit -1
 fi
-echo "Using cargo: $CARGO_BIN"
+if cargo_too_old; then
+    echo "cargo ${CARGO_VER:-(unknown version)} at $CARGO_BIN is older than $RUST_MIN, which the Rust workspaces require."
+    echo "An older cargo is probably still ahead of brew's on \$PATH for $USERNAME."
+    echo "Fix with: sudo -u $USERNAME brew upgrade rust   (or remove the stale ~/.cargo/bin/cargo)"
+    exit -1
+fi
+echo "Using cargo: $CARGO_BIN ($CARGO_VER)"
 
 python3 -m venv ./venv
 source ./venv/bin/activate
@@ -149,6 +178,12 @@ echo "  * Analysis/rust/ — Blue2thprinting-specific tools"
 echo "      (wigle-to-BTIDES, import-all-BTIDES)"
 echo "Release builds, may take a minute or two."
 echo "================================================================================="
+# Hand the tree back before dropping privileges. Everything above ran as root
+# -- the submodule checkout, the venv, the pip installs -- so cargo running as
+# $USERNAME cannot create target/ yet. That failure would exit -1 below, i.e.
+# before the chown at the end of this script, leaving the checkout root-owned
+# and every retry (git pull, submodule update, this script) failing the same way.
+sudo chown -R "$USERNAME" "$BASE_PATH"
 sudo -u "$USERNAME" bash -lc "cd '$BASE_PATH/Analysis/BTIDES_Schema/rust' && cargo build --release"
 if [ $? -ne 0 ]; then
     echo "cargo build failed in Analysis/BTIDES_Schema/rust. Check the output above."

--- a/setup_capture_helper_debian-based.sh
+++ b/setup_capture_helper_debian-based.sh
@@ -413,6 +413,34 @@ build_sniffle_receiver_rust() {
     #
     # On a Pi Zero W the first build takes ~6–12 min single-threaded.
     # Subsequent rebuilds are seconds.
+    #
+    # aarch64 (e.g. Pi Zero 2 W) CANNOT build this crate natively: the 64-bit
+    # rustc segfaults compiling it regardless of toolchain, flags, memory or
+    # swap — even `cargo check` crashes. This is a defect in the aarch64 rustc,
+    # not the source: the same source cross-compiles fine on x86_64. Skip the
+    # doomed native build here; the operator supplies a cross-built binary.
+    # The 32-bit Pi Zero W (armv6l) is unaffected and still builds below.
+    # See PI_ZERO_2W_RUST_BUILD.md for the failure analysis and the cross-build.
+    local arch
+    arch="$(uname -m)"
+    if [ "$arch" = "aarch64" ] || [ "$arch" = "arm64" ]; then
+        local dest="$BASE_PATH/Sniffle/sniffle_receiver_rust"
+        if [ -x "$dest" ]; then
+            echo "  aarch64 host detected; a prebuilt sniffle_receiver_rust is already"
+            echo "  present at Sniffle/sniffle_receiver_rust — keeping it, skipping the build."
+            return 0
+        fi
+        echo ""
+        echo "Blue2thprinting: aarch64 host ($arch) detected — SKIPPING the native cargo"
+        echo "build of sniffle_receiver_rust; the aarch64 rustc segfaults on this crate."
+        echo ""
+        echo "ACTION REQUIRED: cross-compile a static aarch64-musl binary on an x86_64"
+        echo "host and install it at Sniffle/sniffle_receiver_rust, or central_app_launcher.py"
+        echo "will not be able to spawn Sniffle sniffers."
+        echo "Instructions: $BASE_PATH/PI_ZERO_2W_RUST_BUILD.md"
+        echo ""
+        return 0
+    fi
     cd "$BASE_PATH/Sniffle/sniffle_receiver_rust_src"
     # Cargo.lock written by a newer cargo would be rejected by Debian's
     # apt-installed cargo (1.65 on Bookworm); start fresh and let it


### PR DESCRIPTION
Two independent bugs kept setup_analysis_helper_debian-based.sh, and its macOS twin, from completing on a fresh host.

--- The chown ran after the builds that needed it ---

The script runs as root and does its work as root: the recursive submodule checkout, the venv, the pip installs. The two Rust workspace builds then drop back to $SUDO_USER via `sudo -u`, so cargo cannot create target/ inside a root-owned tree and fails with a permission error.

`chown -R "$USERNAME" "$BASE_PATH"` was the last line of the script, and the build failure exits -1 before reaching it. The result is self-perpetuating: the checkout is left root-owned, so every retry -- git pull, git submodule update, or re-running setup -- fails the same way, and the one line that would have repaired the ownership sits downstream of the failure its absence caused.

The chown now also runs immediately before privileges are dropped. The copy at the end of the script is left alone; it is redundant on a clean run and harmless.

--- The toolchain check tested presence, not version ---

`if ! command -v cargo` is satisfied by any cargo at all, including the one setup_capture_helper_debian-based.sh apt-installs, which is 1.65 on Bookworm. The Rust workspaces need >= 1.79, so on a host that runs both the capture and analysis setup, rustup was skipped and the builds failed a hundred lines later on a version error pointing nowhere near the cause.

The gate now parses `cargo --version` and compares major and minor against a named RUST_MIN. It is evaluated twice: once to decide whether to install, and again afterward, because rustup can install correctly into ~/.cargo/bin and still lose to an apt-installed cargo earlier on $PATH. That second check is what catches the real Bookworm failure, and it reports the version, the resolved path and the remedy rather than deferring to a build error.

Absent, truncated or unparseable version output counts as too old, so the installer runs instead of the script optimistically continuing.

--- Also ---

Both scripts resolved BASE_PATH but never cd'd to it, while using relative paths for ./venv and the Analysis subdirectories. Invoked by absolute path from another directory, they created the venv in the caller's working directory and then died on the first cd. They now cd to BASE_PATH once it is resolved.