### PR TITLE
TME: Case insensitive bdaddr

### DIFF
--- a/Analysis/Tell_Me_Everything.py
+++ b/Analysis/Tell_Me_Everything.py
@@ -56,7 +56,7 @@ from TME.TME_BTIDES_base import rebuild_SingleBDADDR_index
 def validate_bdaddr(value):
     if not re.match(r'^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$', value):
         raise argparse.ArgumentTypeError("bdaddr must be in the form of a Bluetooth Device Address (e.g., AA:BB:CC:11:22:33).")
-    return value
+    return value.lower()
 
 
 # Main function to handle command line arguments

--- a/Analysis/rust/BTIDES-to-SQL/src/lib.rs
+++ b/Analysis/rust/BTIDES-to-SQL/src/lib.rs
@@ -2344,7 +2344,7 @@ fn collect_gps_ops(entry: &serde_json::Map<String, J>, b: &mut Buffers) {
         None => return,
     };
     let bdaddr = match entry.get("bdaddr").and_then(|v| v.as_str()) {
-        Some(s) => s.to_string(),
+        Some(s) => s.to_lowercase(),
         None => return,
     };
     let bdaddr_random = match obj_i64(entry, "bdaddr_rand") {


### PR DESCRIPTION
Stored bdaddrs are (almost) always lowercase and DB lookups throughout TME_helpers.py compare against the raw string, so an upper-case --bdadd would otherwise silently match nothing.

So I use `validate_bdaddr` to normalize the bdaddr to lower case. 

When comparing against the rust import script, I realized that the all but the GPS import use `to_lowercase`.
I aligned it accordingly. However, I have no data for testing the import.

As a suggestion, specifying that bdaddr is always lowercase in [BTIDES_Schema](https://github.com/darkmentorllc/BTIDES_Schema/blob/fb77e29db486f2c11734e8cffac48b9f6e7d2eae/BTIDES_base.json#L211), might prevent future confusion.